### PR TITLE
Dynamically generate the README.md from command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# wp-cli-piwik
-Wp-cli package for configuring the wp-piwik plugin.
+adrigen/wp-cli-piwik
+====================
+
+Add a `wp piwik` command to support the WP-Piwik plugin
+
+
+Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contributing)
+
+## Using
+
+This package implements the following commands:
+
+### wp piwiki url
+
+
+
+~~~
+wp piwiki url 
+~~~
+
+
+
+### wp piwik token
+
+Set auth token.
+
+~~~
+wp piwik token <token>
+~~~
+
+**OPTIONS**
+
+	<token>
+		Enter your Piwik auth token here. It is an alphanumerical code like 0a1b2c34d56e78901fa2bc3d45678efa (see WP-Piwik faq for more info)
+
+**EXAMPLES**
+
+    wp piwik token 0a1b2c34d56e78901fa2bc3d45678efa
+
+
+
+## Installing
+
+Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
+
+Once you've done so, you can install this package with `wp package install adrigen/wp-cli-piwik`
+
+## Contributing
+
+Code and ideas are more than welcome.
+
+Please [open an issue](https://github.com/adrigen/wp-cli-piwik/issues) with questions, feedback, and violent dissent. Pull requests are expected to include test coverage.

--- a/command.php
+++ b/command.php
@@ -6,7 +6,7 @@ if ( !defined( 'WP_CLI' ) ) return;
 class Piwik_Command extends WP_CLI_Command {
 
     /**
-     *  Set piwik url.
+     * Set piwik url.
      * 
      * ## OPTIONS
      * 
@@ -15,7 +15,7 @@ class Piwik_Command extends WP_CLI_Command {
      * 
      * ## EXAMPLES
      * 
-     *     wp example url http://www.example.com/piwik/ 
+     *     wp piwiki url http://www.example.com/piwik/ 
      *
      * @synopsis <url>
      */

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,11 @@
     "autoload": {
         "files": [ "command.php" ]
 
+    },
+    "extras": {
+        "commands": [
+            "piwiki url",
+            "piwik token"
+        ]
     }
 }


### PR DESCRIPTION
Using `wp --require=command.php scaffold package-readme ./ --force`